### PR TITLE
fix: github org in function calls

### DIFF
--- a/backend/api/server/prow_rotate.go
+++ b/backend/api/server/prow_rotate.go
@@ -266,7 +266,7 @@ func (s *Server) ErrorsUpdateInProwJobs() {
 				prNumber := getPRNumber(pj.JobURL)
 
 				if prNumber != "" {
-					suites, _ = s.cfg.GCS.GetJobJunitContent("konflux-ci", "infra-deployments", prNumber,
+					suites, _ = s.cfg.GCS.GetJobJunitContent("redhat-appstudio", "infra-deployments", prNumber,
 						pj.JobID, pj.JobType, pj.JobName, JunitRegexpSearch)
 				} else {
 					s.cfg.Logger.Sugar().Debug("Failed to get pr number from ", pj.JobURL)

--- a/backend/pkg/connectors/codecov/codecov_test.go
+++ b/backend/pkg/connectors/codecov/codecov_test.go
@@ -13,7 +13,7 @@ var repository = repoV1Alpha1.Repository{
 	ID:   "12345678",
 	Name: "managed-gitops",
 	Owner: repoV1Alpha1.Owner{
-		Login: "konflux-ci",
+		Login: "redhat-appstudio",
 	},
 	Description: "GitOps Service: Backend/cluster-agent/utility components aiming to provided GitOps services via Kubernetes-controller-managed Argo CD",
 	URL:         "https://github.com/redhat-appstudio/managed-gitops",

--- a/backend/pkg/storage/ent/client/repository_test.go
+++ b/backend/pkg/storage/ent/client/repository_test.go
@@ -14,7 +14,7 @@ var toCreate = s.Repository{
 	ID:   "12345678",
 	Name: "managed-gitops",
 	Owner: s.Owner{
-		Login: "konflux-ci",
+		Login: "redhat-appstudio",
 	},
 	Description: "GitOps Service: Backend/cluster-agent/utility components aiming to provided GitOps services via Kubernetes-controller-managed Argo CD",
 	URL:         "https://github.com/redhat-appstudio/managed-gitops",

--- a/frontend/src/app/FlakyTests/FlakyTests.tsx
+++ b/frontend/src/app/FlakyTests/FlakyTests.tsx
@@ -206,7 +206,7 @@ const FlakyTests: React.FunctionComponent = () => {
   const fetchData = () => {
     setLoadingSpinner(true)
     if (startDate && endDate && selectedRepo && selectedRepo) {
-      getFlakyData(currentTeam, selectedJob, selectedRepo, rangeDateTime, "konflux-ci").then(res => {
+      getFlakyData(currentTeam, selectedJob, selectedRepo, rangeDateTime, "redhat-appstudio").then(res => {
         if (res.code == 200) {
           const impact: FlakyObject = res.data
           if (impact && impact.suites) {
@@ -221,7 +221,7 @@ const FlakyTests: React.FunctionComponent = () => {
           console.log("error", res)
         }
       })
-      getGlobalImpactData(currentTeam, selectedJob, selectedRepo, rangeDateTime, "konflux-ci").then(res => {
+      getGlobalImpactData(currentTeam, selectedJob, selectedRepo, rangeDateTime, "redhat-appstudio").then(res => {
         if (res.code == 200) {
           const impact: any = res.data
           if (impact && impact.length > 0) {


### PR DESCRIPTION
There are some function calls where the github organization is hardcoded. After migration to `konflux-ci`, these wouldn't work for example for infra-deployments repo, that stays in `redhat-appstudio` github org.

Keeping "redhat-appstudio" github org even for migrated repositories should be fine, because github automatically redirects API calls to the new organization ("konflux-ci")

I filed a jira for fixing this: https://issues.redhat.com/browse/AD-193


