### PR TITLE
docs: fix link to failure code

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ We are saving two types of error messages:
  - E2E Failed Test Messages: Messages related to failed E2E tests.
  - Build Error Logs: If there is no E2E Failed Test Messages, we save the last 50 lines of the build-log.txt in order to help us find infra errors, for example. We are only saving the last 50 days because we believe it is enough to catch the build errors.
 
-To calculate the impact of each failure (in the Failures table), in the date time range selected, we will search for all the prow jobs and verify in how many prow jobs the bug's error message is present in the E2E Failed Test Messages or Build Error Logs. You can find the code (here)[https://github.com/konflux-ci/quality-dashboard/blob/main/backend/pkg/storage/ent/client/failure.go].
+To calculate the impact of each failure (in the Failures table), in the date time range selected, we will search for all the prow jobs and verify in how many prow jobs the bug's error message is present in the E2E Failed Test Messages or Build Error Logs. You can find the code [here](https://github.com/konflux-ci/quality-dashboard/blob/main/backend/pkg/storage/ent/client/failure.go).
 
 ## Connectors
 


### PR DESCRIPTION
Parentheses and brackets in the link are accidentally switched in the README. 

This PR fixes that resulting in a properly formatted Markdown link to the failure code.