### PR TITLE
Use docker-build pipeline from quay.io/konflux-ci

### DIFF
--- a/.tekton/pull-request-backend.yaml
+++ b/.tekton/pull-request-backend.yaml
@@ -18,7 +18,7 @@ spec:
       value: "backend"
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+    bundle: quay.io/konflux-ci/tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/pull-request-frontend.yaml
+++ b/.tekton/pull-request-frontend.yaml
@@ -18,7 +18,7 @@ spec:
       value: "frontend"
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+    bundle: quay.io/konflux-ci/tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/push-backend.yaml
+++ b/.tekton/push-backend.yaml
@@ -18,7 +18,7 @@ spec:
       value: "backend"
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+    bundle: quay.io/konflux-ci/tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/push-frontend.yaml
+++ b/.tekton/push-frontend.yaml
@@ -23,7 +23,7 @@ spec:
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/quality-dashboard/base/frontend/kustomization.yaml
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+    bundle: quay.io/konflux-ci/tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:


### PR DESCRIPTION
STONEBLD-2720

The pipeline bundles in quay.io/redhat-appstudio-tekton-catalog are
deprecated, they will no longer receive updates.

Get the bundle from quay.io/konflux-ci/tekton-catalog instead.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
