### PR TITLE
fix: pipeline references

### DIFF
--- a/.tekton/pull-request-backend.yaml
+++ b/.tekton/pull-request-backend.yaml
@@ -17,8 +17,14 @@ spec:
     - name: path-context
       value: "backend"
   pipelineRef:
-    name: docker-build
-    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+    resolver: bundles
+    params:
+      - name: name
+        value: docker-build
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-core-services-docker-build:latest
+      - name: kind
+        value: Pipeline
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/pull-request-frontend.yaml
+++ b/.tekton/pull-request-frontend.yaml
@@ -17,8 +17,14 @@ spec:
     - name: path-context
       value: "frontend"
   pipelineRef:
-    name: docker-build
-    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+    resolver: bundles
+    params:
+      - name: name
+        value: docker-build
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-core-services-docker-build:latest
+      - name: kind
+        value: Pipeline
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/push-backend.yaml
+++ b/.tekton/push-backend.yaml
@@ -17,8 +17,14 @@ spec:
     - name: path-context
       value: "backend"
   pipelineRef:
-    name: docker-build
-    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+    resolver: bundles
+    params:
+      - name: name
+        value: docker-build
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-core-services-docker-build:latest
+      - name: kind
+        value: Pipeline
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/push-frontend.yaml
+++ b/.tekton/push-frontend.yaml
@@ -22,8 +22,14 @@ spec:
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/quality-dashboard/base/dex/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/quality-dashboard/base/frontend/kustomization.yaml
   pipelineRef:
-    name: docker-build
-    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+    resolver: bundles
+    params:
+      - name: name
+        value: docker-build
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-core-services-docker-build:latest
+      - name: kind
+        value: Pipeline
   workspaces:
     - name: workspace
       volumeClaimTemplate:


### PR DESCRIPTION
* fixed the syntax for referencing pipeline bundles
* replaced the bundle ref with the one that was migrated to konflux-ci quay org: `quay.io/konflux-ci/tekton-catalog/pipeline-core-services-docker-build:latest`